### PR TITLE
Id3b dev

### DIFF
--- a/configs/ID3B.json
+++ b/configs/ID3B.json
@@ -117,15 +117,14 @@
   },
   {
     "key": "beam_energy",
-    "type": "list_float",
+    "type": "float64",
     "optional": true,
     "multiple": false,
     "section": "Beam",
-    "description": "Beam energy [keV]",
-    "units": "keV",
+    "description": "Beam energy [KeV]",
+    "units": "KeV",
     "placeholder": "9.7",
-    "value": [
-      "",      
+    "value": [       
       9.7,
       15.9,
       18.65,
@@ -171,7 +170,7 @@
     "section": "Experiment",
     "description": "Detectors used",
     "units": "",
-    "placeholder": "pilatus_300K_pil5",
+    "placeholder": "pilatus_300K_pil5, pilatus_200K_pil9, pilatus_200K_pil11",
     "value": [
       "",
       "pilatus_300K_pil5",

--- a/configs/ID3B.json
+++ b/configs/ID3B.json
@@ -78,6 +78,84 @@
     "description": "The relative path from the raw BTR directory to the spec file, including the spec file name",
     "units": "",
     "placeholder": "/"
-  }   
-  
+  },  
+  {
+    "key": "monochromator",
+    "type": "list_str",
+    "optional": true,
+    "multiple": false,
+    "section": "Beam",
+    "description": "Monochromator type used",
+    "units": "",
+    "placeholder": "diamond111",
+    "value": [
+      "",      
+      "diamond111",
+      "diamond220",
+      "diamond311",
+      "diamond400",
+      "diamond333"
+    ]
+  },
+  {
+    "key": "beam_energy",
+    "type": "list_float",
+    "optional": true,
+    "multiple": false,
+    "section": "Beam",
+    "description": "Beam energy [keV]",
+    "units": "keV",
+    "placeholder": "9.7, 15.9, 18.65, 22,5, 29.1"
+  },  
+  {
+    "key": "mirror",
+    "type": "list_str",
+    "optional": true,
+    "multiple": false,
+    "section": "Beam",
+    "description": "Mirror position",
+    "units": "",
+    "placeholder": "In",
+    "value": [
+      "",
+      "in",
+      "out"
+    ]
+  },
+  {
+    "key": "beam_mode",
+    "type": "list_str",
+    "optional": true,
+    "multiple": false,
+    "section": "Beam",
+    "description": "Focusing optic used, if any",
+    "units": "",
+    "placeholder": "Bulk",
+    "value": [
+      "",
+      "bulk",
+      "CRL"
+    ]
+  },
+  {
+    "key": "detectors",
+    "type": "list_str",
+    "optional": true,
+    "multiple": true,
+    "section": "Experiment",
+    "description": "Detectors used",
+    "units": "",
+    "placeholder": "pilatus_300K_pil5",
+    "value": [
+      "",
+      "pilatus_300K_pil5",
+      "pilatus_200K_pil9",
+      "pilatus_200K_pil11",      
+      "eiger_1M",
+      "andor2",
+      "vortex",            
+      "manta",
+      "other"
+    ]
+  }  
 ]

--- a/configs/ID3B.json
+++ b/configs/ID3B.json
@@ -7,7 +7,7 @@
     "section": "User",
     "description": "Dataset IDentifier",
     "units": "",
-    "placeholder": "/beamline=3b/"
+    "placeholder": "/"
   },
   {
     "key": "facility",

--- a/configs/ID3B.json
+++ b/configs/ID3B.json
@@ -174,6 +174,15 @@
     ]
   },
   {
+    "key": "polymer_type",
+    "type": "string",
+    "optional": true,
+    "multiple": false,
+    "section": "Experiment",
+    "description": "Is this an in-situ experiment?",
+    "placeholder": "PEEK"
+  },
+  {
     "key": "bed_temperature_set",
     "type": "float64",
     "optional": true,
@@ -221,5 +230,6 @@
     "section": "Experiment",
     "description": "Heated print bed: Roller feed rate in mm/s",
     "units": "mm/s",
-    "placeholder": ""  }    
+    "placeholder": ""  
+  }    
 ]

--- a/configs/ID3B.json
+++ b/configs/ID3B.json
@@ -80,6 +80,24 @@
     "placeholder": "/"
   },  
   {
+    "key": "cesr_conditions",
+    "type": "list_str",
+    "optional": true,
+    "multiple": false,
+    "section": "Beam",
+    "description": "CESR fill pattern",
+    "units": "",
+    "placeholder": "9x5_bunch_mode",
+    "value": [
+      "",
+      "9_bunch_mode",
+      "21_bunch_mode",
+      "9x5_bunch_mode",
+      "13_bunch_mode",
+      "other"
+    ]
+  },   
+  {
     "key": "monochromator",
     "type": "list_str",
     "optional": true,
@@ -179,7 +197,7 @@
     "optional": true,
     "multiple": false,
     "section": "Experiment",
-    "description": "Is this an in-situ experiment?",
+    "description": "Specify polymer type",
     "placeholder": "PEEK"
   },
   {

--- a/configs/ID3B.json
+++ b/configs/ID3B.json
@@ -234,7 +234,9 @@
       "linkam_shear",
       "linkam_tensile",
       "linkam_heating",
-      "rams4"
+      "ramsiv",
+      "cclf",
+      "bose"
     ]
   },
   {

--- a/configs/ID3B.json
+++ b/configs/ID3B.json
@@ -7,7 +7,7 @@
     "section": "User",
     "description": "Dataset IDentifier",
     "units": "",
-    "placeholder": "CHESS"
+    "placeholder": "/beamline=3b/"
   },
   {
     "key": "facility",
@@ -123,7 +123,15 @@
     "section": "Beam",
     "description": "Beam energy [keV]",
     "units": "keV",
-    "placeholder": "9.7, 15.9, 18.65, 22,5, 29.1"
+    "placeholder": "9.7",
+    "value": [
+      "",      
+      9.7,
+      15.9,
+      18.65,
+      22.5,
+      29.1
+    ]
   },  
   {
     "key": "mirror",
@@ -133,7 +141,7 @@
     "section": "Beam",
     "description": "Mirror position",
     "units": "",
-    "placeholder": "In",
+    "placeholder": "in",
     "value": [
       "",
       "in",
@@ -148,7 +156,7 @@
     "section": "Beam",
     "description": "Focusing optic used, if any",
     "units": "",
-    "placeholder": "Bulk",
+    "placeholder": "CRL",
     "value": [
       "",
       "bulk",
@@ -259,27 +267,37 @@
     "placeholder": ""
   },
   {
-    "key": "nozzle_rate",
+    "key": "nozzle_scan_speed",
     "type": "float64",
     "optional": true,
     "multiple": false,
     "section": "Experiment",
-    "description": "Heated print bed: Nozzle rate in mm/s",
+    "description": "Heated print bed: Nozzle scan speed in mm/s",
     "units": "mm/s",
     "placeholder": ""
   },
   {
-    "key": "bed_rate",
+    "key": "bed_scan_speed",
     "type": "float64",
     "optional": true,
     "multiple": false,
     "section": "Experiment",
-    "description": "Heated print bed: Bed rate in mm/s",
+    "description": "Heated print bed: Bed scan speed in mm/s",
     "units": "mm/s",
     "placeholder": ""
-  },  
+  },
   {
-    "key": "feed_rate",
+    "key": "print_speed",
+    "type": "float64",
+    "optional": true,
+    "multiple": false,
+    "section": "Experiment",
+    "description": "Heated print bed: Print speed in mm/s",
+    "units": "mm/s",
+    "placeholder": ""
+  },
+  {
+    "key": "roller_feed_rate",
     "type": "float64",
     "optional": true,
     "multiple": false,

--- a/configs/ID3B.json
+++ b/configs/ID3B.json
@@ -45,9 +45,9 @@
     "optional": false,
     "multiple": false,
     "section": "User",
-    "description": "Specify the run cycle (e.g. 2025-1)",
+    "description": "Specify the run cycle (e.g. 2025-2)",
     "units": "",
-    "placeholder": "2025-1"
+    "placeholder": "2025-2"
   },
   {
     "key": "btr",
@@ -244,8 +244,8 @@
     "optional": true,
     "multiple": false,
     "section": "Experiment",
-    "description": "Heated print bed: Set bed temperature in degC",
-    "units": "degC",
+    "description": "Heated print bed: Set bed temperature in degrees Celsius",
+    "units": "celsius",
     "placeholder": ""
   },
   {
@@ -254,8 +254,8 @@
     "optional": true,
     "multiple": false,
     "section": "Experiment",
-    "description": "Heated print bed: Nozzle temperature in degC",
-    "units": "degC",
+    "description": "Heated print bed: Nozzle temperature in degrees Celsius",
+    "units": "celsius",
     "placeholder": ""
   },
   {

--- a/configs/ID3B.json
+++ b/configs/ID3B.json
@@ -123,7 +123,7 @@
     ]
   },
   {
-    "key": "beam_mode",
+    "key": "focusing",
     "type": "list_str",
     "optional": true,
     "multiple": false,
@@ -157,5 +157,69 @@
       "manta",
       "other"
     ]
-  }  
+  },
+  {
+    "key": "in_situ",
+    "type": "bool",
+    "optional": true,
+    "multiple": false,
+    "section": "Experiment",
+    "description": "Is this an in-situ experiment?",
+    "units": "",
+    "placeholder": "false",
+    "value": [
+      "",
+      "true",
+      "false"
+    ]
+  },
+  {
+    "key": "bed_temperature_set",
+    "type": "float64",
+    "optional": true,
+    "multiple": false,
+    "section": "Experiment",
+    "description": "Heated print bed: Set bed temperature in degC",
+    "units": "degC",
+    "placeholder": ""
+  },
+  {
+    "key": "nozzle_temperature",
+    "type": "float64",
+    "optional": true,
+    "multiple": false,
+    "section": "Experiment",
+    "description": "Heated print bed: Nozzle temperature in degC",
+    "units": "degC",
+    "placeholder": ""
+  },
+  {
+    "key": "nozzle_rate",
+    "type": "float64",
+    "optional": true,
+    "multiple": false,
+    "section": "Experiment",
+    "description": "Heated print bed: Nozzle rate in mm/s",
+    "units": "mm/s",
+    "placeholder": ""
+  },
+  {
+    "key": "bed_rate",
+    "type": "float64",
+    "optional": true,
+    "multiple": false,
+    "section": "Experiment",
+    "description": "Heated print bed: Bed rate in mm/s",
+    "units": "mm/s",
+    "placeholder": ""
+  },  
+  {
+    "key": "feed_rate",
+    "type": "float64",
+    "optional": true,
+    "multiple": false,
+    "section": "Experiment",
+    "description": "Heated print bed: Roller feed rate in mm/s",
+    "units": "mm/s",
+    "placeholder": ""  }    
 ]

--- a/configs/ID3B.json
+++ b/configs/ID3B.json
@@ -177,6 +177,26 @@
     ]
   },
   {
+    "key": "technique",
+    "type": "list_str",
+    "optional": true,
+    "multiple": true,
+    "section": "Experiment",
+    "description": "Experimental technique(s)",
+    "units": "",
+    "placeholder": "SAXS+WAXS",
+    "value": [
+      "",
+      "SAXS+WAXS",
+      "SAXS",
+      "WAXS",
+      "xray_fluorescence",
+      "tomography",
+      "radiography",
+      "other"
+    ]
+  },
+  {
     "key": "in_situ",
     "type": "bool",
     "optional": true,
@@ -189,6 +209,24 @@
       "",
       "true",
       "false"
+    ]
+  },
+  {
+    "key": "processing_environment",
+    "type": "list_str",
+    "optional": true,
+    "multiple": false,
+    "section": "Experiment",
+    "description": "In-situ processing environment used, if any",
+    "units": "",
+    "placeholder": "",
+    "value": [
+      "",
+      "heated_print_bed",
+      "linkam_shear",
+      "linkam_tensile",
+      "linkam_heating",
+      "rams4"
     ]
   },
   {


### PR DESCRIPTION
This updated schema has additional optional keys, including "beam_energy" with "type": "float64" and "value" with [finite beam energy options]. 